### PR TITLE
chore: track build time

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,7 +10,8 @@ console.log(`Building ${packageJson.name} v${packageJson.version}...`);
 
 try {
   console.log('🏗️ Starting production build process...');
-  
+  const start = Date.now();
+
   // Run tests first (critical for production)
   console.log('🧪 Running test suite...');
   try {
@@ -139,7 +140,7 @@ Version: ${packageJson.version}
   console.log('🎯 Project is ready for production deployment!');
   console.log('📁 Distribution files created in ./dist directory');
   console.log('🔧 Run "cd dist && npm install --production && npm start"');
-  console.log(`📊 Build completed in ${Date.now() - Date.now()} ms`);
+  console.log(`📊 Build completed in ${Date.now() - start} ms`);
   
 } catch (error) {
   console.error('❌ Build failed:', error.message);


### PR DESCRIPTION
## Summary
- start timer at beginning of production build
- report elapsed time using start timestamp

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b8d69eb4dc832d8fafdb2a34d7bb56