### PR TITLE
feat: expose server configuration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ curl -X POST https://llmrouter.dev:3006/api/chat \
   -d '{"message": "Hello, AI!"}'
 ```
 
+### Get Server Configuration
+```bash
+curl https://llmrouter.dev:3006/api/config
+```
+
 ### Key Files to Know
 - `server.js` - Main server entry point
 - `src/index.js` - Core LLMRouter class

--- a/public/chat/config-manager.js
+++ b/public/chat/config-manager.js
@@ -23,16 +23,15 @@ class ConfigManager {
             this.config = this.getDefaultConfig();
         }
         
-        // Server config sync temporarily disabled
-        // TODO: Add /api/config endpoint if needed
+        // Sync with server configuration
         try {
-            // const response = await fetch(`${this.apiUrl}/api/config`);
-            // if (response.ok) {
-            //     const serverConfig = await response.json();
-            //     // Merge with local config
-            //     this.config = { ...this.config, ...serverConfig };
-            //     this.saveConfig();
-            // }
+            const response = await fetch(`${this.apiUrl}/api/config`);
+            if (response.ok) {
+                const serverConfig = await response.json();
+                // Merge with local config
+                this.config = { ...this.config, ...serverConfig };
+                this.saveConfig();
+            }
         } catch (error) {
             console.debug('Could not fetch server config, using local:', error);
         }

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ import WebSocketAPI from './src/api/WebSocket.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import Config from './src/config/Config.js';
 
 // Import authentication middleware
 import { 
@@ -75,9 +76,16 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(enableCORS);
 
 // Create a single global router instance
-const router = new LLMRouter({ 
+const router = new LLMRouter({
   autoInit: false,
   strategy: process.env.ROUTING_STRATEGY || 'balanced'
+});
+
+// Server configuration
+const serverConfig = new Config({
+  routingStrategy: process.env.ROUTING_STRATEGY || 'balanced',
+  apiPort: PORT,
+  apiHost: HOST
 });
 
 // Global model loading status
@@ -247,6 +255,13 @@ app.get('/api/status', (req, res) => {
     version: '2.0.0',
     environment: process.env.NODE_ENV || 'production'
   });
+});
+
+/**
+ * Configuration endpoint (public)
+ */
+app.get('/api/config', (req, res) => {
+  res.json(serverConfig.exportForClient());
 });
 
 /**


### PR DESCRIPTION
## Summary
- add `/api/config` route to serve server configuration
- sync chat config-manager with `/api/config`
- document config endpoint in README

## Testing
- `npm run lint` *(fails: 'Deno' is not defined, etc.)*
- `npm test` *(fails: require is not defined, sharp module missing)*
- `npm start` *(fails: sharp module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dab47054832d89a0d20472fa394f