### PR TITLE
feat(router): improve cache key hashing

### DIFF
--- a/dist/src/core/Router.js
+++ b/dist/src/core/Router.js
@@ -5,6 +5,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
 import { Logger } from '../utils/Logger.js';
 import { CostOptimizer } from './CostOptimizer.js';
 import { QualityScorer } from './QualityScorer.js';
@@ -469,12 +470,11 @@ class Router extends EventEmitter {
   /**
    * Get cache key for route
    * @private
-   */
+  */
   getCacheKey(prompt, requirements) {
-    // Simple hash - in production, use proper hashing
-    const promptHash = prompt.substring(0, 50);
-    const reqHash = JSON.stringify(requirements);
-    return `${promptHash}_${reqHash}`;
+    return createHash('sha256')
+      .update(prompt + JSON.stringify(requirements))
+      .digest('hex');
   }
 
   /**

--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -5,6 +5,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
 import { Logger } from '../utils/Logger.js';
 import { CostOptimizer } from './CostOptimizer.js';
 import { QualityScorer } from './QualityScorer.js';
@@ -469,12 +470,11 @@ class Router extends EventEmitter {
   /**
    * Get cache key for route
    * @private
-   */
+  */
   getCacheKey(prompt, requirements) {
-    // Simple hash - in production, use proper hashing
-    const promptHash = prompt.substring(0, 50);
-    const reqHash = JSON.stringify(requirements);
-    return `${promptHash}_${reqHash}`;
+    return createHash('sha256')
+      .update(prompt + JSON.stringify(requirements))
+      .digest('hex');
   }
 
   /**


### PR DESCRIPTION
## Summary
- use Node crypto to hash prompt and requirements for cache keys
- update built router to use the new SHA-256 cache key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b8e0544c74832d8ee01dcadcbe037a