### PR TITLE
Handle array sanitization in middleware

### DIFF
--- a/dist/src/middleware/security.js
+++ b/dist/src/middleware/security.js
@@ -104,18 +104,33 @@ export function validateInput(req, res, next) {
  * Sanitize object recursively
  */
 function sanitizeObject(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(item => {
+      if (typeof item === 'string') {
+        return item
+          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+          .replace(/javascript:/gi, '')
+          .replace(/on\w+\s*=/gi, '');
+      }
+      if (typeof item === 'object') {
+        return sanitizeObject(item);
+      }
+      return item;
+    });
+  }
+
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
-  
+
   const sanitized = {};
-  
+
   for (const [key, value] of Object.entries(obj)) {
     // Skip potentially dangerous properties
     if (key.startsWith('__') || key.includes('prototype')) {
       continue;
     }
-    
+
     if (typeof value === 'string') {
       // Remove potential script tags and other dangerous content
       sanitized[key] = value
@@ -128,7 +143,7 @@ function sanitizeObject(obj) {
       sanitized[key] = value;
     }
   }
-  
+
   return sanitized;
 }
 

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -104,18 +104,33 @@ export function validateInput(req, res, next) {
  * Sanitize object recursively
  */
 function sanitizeObject(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(item => {
+      if (typeof item === 'string') {
+        return item
+          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+          .replace(/javascript:/gi, '')
+          .replace(/on\w+\s*=/gi, '');
+      }
+      if (typeof item === 'object') {
+        return sanitizeObject(item);
+      }
+      return item;
+    });
+  }
+
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
-  
+
   const sanitized = {};
-  
+
   for (const [key, value] of Object.entries(obj)) {
     // Skip potentially dangerous properties
     if (key.startsWith('__') || key.includes('prototype')) {
       continue;
     }
-    
+
     if (typeof value === 'string') {
       // Remove potential script tags and other dangerous content
       sanitized[key] = value
@@ -128,7 +143,7 @@ function sanitizeObject(obj) {
       sanitized[key] = value;
     }
   }
-  
+
   return sanitized;
 }
 

--- a/tests/utils/sanitizeObject.test.js
+++ b/tests/utils/sanitizeObject.test.js
@@ -1,0 +1,24 @@
+import { validateInput } from '../../src/middleware/security.js';
+
+describe('sanitizeObject array handling', () => {
+  test('sanitizes nested arrays while preserving structure', () => {
+    const req = {
+      body: {
+        arr: [
+          '<script>alert(1)</script>',
+          ['javascript:attack()', '<img src=x onerror=alert(2)>'],
+          { nested: ['safe', '<script>bad()</script>'] }
+        ]
+      }
+    };
+
+    validateInput(req, {}, () => {});
+
+    expect(Array.isArray(req.body.arr)).toBe(true);
+    expect(Array.isArray(req.body.arr[1])).toBe(true);
+    expect(Array.isArray(req.body.arr[2].nested)).toBe(true);
+    expect(req.body).toEqual({
+      arr: ['', ['attack()', '<img src=x alert(2)>'], { nested: ['safe', ''] }]
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend sanitizeObject to handle arrays without altering structure
- add test for nested array sanitization

## Testing
- `npm run lint` (fails: 193 problems, 30 errors)
- `npm test` (fails: jest-haste-map naming collision)
- `node --experimental-vm-modules node_modules/.bin/jest tests/utils/sanitizeObject.test.js`
- `npm start` (fails: missing sharp module)


------
https://chatgpt.com/codex/tasks/task_e_68b8e03ebdd4832d944c01377b28a264