### PR TITLE
Manage router monitoring intervals

### DIFF
--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -50,7 +50,7 @@ class Router extends EventEmitter {
     // Routing cache
     this.routeCache = new Map();
     this.modelScores = new Map();
-    
+
     // Statistics
     this.stats = {
       totalRoutes: 0,
@@ -58,7 +58,11 @@ class Router extends EventEmitter {
       failures: 0,
       avgLatency: 0
     };
-    
+
+    // Monitoring intervals
+    this.cacheCleanupInterval = null;
+    this.scoreRecomputeInterval = null;
+
     // Expose strategy property for tests
     this.strategy = this.config.strategy;
     
@@ -70,13 +74,16 @@ class Router extends EventEmitter {
    */
   async initialize(engine) {
     this.engine = engine;
-    
+
+    // Ensure previous monitoring intervals are cleared
+    this.stopMonitoring();
+
     // Precompute model scores
     await this.computeModelScores();
-    
+
     // Setup monitoring
     this.startMonitoring();
-    
+
     logger.info('✅ Router ready with engine:', engine.name);
   }
 
@@ -494,7 +501,7 @@ class Router extends EventEmitter {
    */
   startMonitoring() {
     // Periodic cache cleanup
-    setInterval(() => {
+    this.cacheCleanupInterval = setInterval(() => {
       const now = Date.now();
       for (const [key, value] of this.routeCache.entries()) {
         if (now - value.timestamp > this.config.cacheTTL) {
@@ -502,11 +509,26 @@ class Router extends EventEmitter {
         }
       }
     }, 60000); // Every minute
-    
+
     // Periodic score recomputation
-    setInterval(() => {
+    this.scoreRecomputeInterval = setInterval(() => {
       this.computeModelScores().catch(console.error);
     }, 300000); // Every 5 minutes
+  }
+
+  /**
+   * Stop monitoring
+   * @private
+   */
+  stopMonitoring() {
+    if (this.cacheCleanupInterval) {
+      clearInterval(this.cacheCleanupInterval);
+      this.cacheCleanupInterval = null;
+    }
+    if (this.scoreRecomputeInterval) {
+      clearInterval(this.scoreRecomputeInterval);
+      this.scoreRecomputeInterval = null;
+    }
   }
 
   /**
@@ -694,6 +716,7 @@ class Router extends EventEmitter {
    * });
    */
   async cleanup() {
+    this.stopMonitoring();
     this.routeCache.clear();
     this.modelScores.clear();
     this.removeAllListeners();

--- a/src/index.js
+++ b/src/index.js
@@ -407,8 +407,9 @@ class LLMRouter {
    */
   async cleanup() {
     logger.info('🧹 Cleaning up resources...');
-    
+
     await this.pipeline.cleanup();
+    this.router.stopMonitoring();
     await this.router.cleanup();
     await this.registry.cleanup();
     await this.engine?.cleanup();


### PR DESCRIPTION
## Summary
- track cache cleanup and score recompute intervals in Router
- provide `stopMonitoring` to clear intervals and avoid leaks
- invoke `stopMonitoring` during router initialization and cleanup
- ensure app-level cleanup stops monitoring before shutting down

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '.../node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b8e0435880832dab7227bb9dd33d46