### PR TITLE
chore: remove unused RateLimiterRedis import

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -5,7 +5,6 @@
 
 import { APIKeyManager } from '../auth/APIKeyManager.js';
 import rateLimit from 'express-rate-limit';
-import { RateLimiterRedis } from 'rate-limiter-flexible';
 
 // Global API key manager instance
 let apiKeyManager = null;


### PR DESCRIPTION
## Summary
- remove unused RateLimiterRedis import from auth middleware

## Testing
- `npm run lint` (fails: missing definitions across project)
- `npm test` (fails: Haste module naming collision)
- `npm start` (fails: sharp module missing)


------
https://chatgpt.com/codex/tasks/task_e_68b8e0460cb0832d98faf641f420d12e