### PR TITLE
refactor: use node crypto module in auth

### DIFF
--- a/dist/src/api/Auth.js
+++ b/dist/src/api/Auth.js
@@ -11,6 +11,7 @@ import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { Strategy as OAuth2Strategy } from 'passport-oauth2';
 import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from 'events';
+import crypto from 'node:crypto';
 
 export class AuthenticationManager extends EventEmitter {
   constructor(options = {}) {
@@ -684,7 +685,6 @@ export class AuthenticationManager extends EventEmitter {
    * Generate secure random secret
    */
   generateSecureSecret() {
-    const crypto = require('crypto');
     const secret = crypto.randomBytes(64).toString('hex');
     console.warn('🚨 SECURITY WARNING: Using auto-generated secret. Set JWT_SECRET and SESSION_SECRET environment variables for production.');
     return secret;

--- a/src/api/Auth.js
+++ b/src/api/Auth.js
@@ -11,6 +11,7 @@ import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { Strategy as OAuth2Strategy } from 'passport-oauth2';
 import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from 'events';
+import crypto from 'node:crypto';
 
 export class AuthenticationManager extends EventEmitter {
   constructor(options = {}) {
@@ -684,7 +685,6 @@ export class AuthenticationManager extends EventEmitter {
    * Generate secure random secret
    */
   generateSecureSecret() {
-    const crypto = require('crypto');
     const secret = crypto.randomBytes(64).toString('hex');
     console.warn('🚨 SECURITY WARNING: Using auto-generated secret. Set JWT_SECRET and SESSION_SECRET environment variables for production.');
     return secret;


### PR DESCRIPTION
## Summary
- refactor Auth generateSecureSecret to use `import crypto from 'node:crypto'`
- remove dynamic require in both source and built files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express' imported from server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e04d4240832dbc02f0ced02f76a7