### PR TITLE
Ensure build script aborts on test or lint errors

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,21 +14,13 @@ try {
 
   // Run tests first (critical for production)
   console.log('🧪 Running test suite...');
-  try {
-    execSync('npm test', { stdio: 'pipe' });
-    console.log('✅ All tests passed');
-  } catch (testError) {
-    console.warn('⚠️ Some tests failed, but continuing build (check logs)');
-  }
-  
-  // Run linting (warn but don't fail build)
+  execSync('npm test', { stdio: 'inherit' });
+  console.log('✅ All tests passed');
+
+  // Run linting
   console.log('🔍 Running ESLint...');
-  try {
-    execSync('npm run lint', { stdio: 'inherit' });
-    console.log('✅ ESLint passed');
-  } catch (lintError) {
-    console.warn('⚠️ ESLint found issues but continuing build...');
-  }
+  execSync('npm run lint', { stdio: 'inherit' });
+  console.log('✅ ESLint passed');
   
   // Format code
   console.log('✨ Formatting code...');


### PR DESCRIPTION
## Summary
- Remove try/catch around test and lint in build script so failures stop the build
- Use `stdio: 'inherit'` for clearer output from tests and linting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b8e4128eac832db7869827c4ab3705