### PR TITLE
feat: load env vars before server startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,14 +1,17 @@
 /**
  * 🚀 LLM Router Server - Unified Production Server
- * 
+ *
  * Configurable server supporting multiple modes:
  * - DEFAULT: Standard production mode with HTTPS (default)
  * - HTTP: Development mode without HTTPS
  * - SECURE: Enhanced security with rate limiting and headers
  * - RESILIENT: Self-healing with auto-recovery
- * 
+ *
  * Set SERVER_MODE environment variable to change modes
  */
+
+import dotenv from 'dotenv';
+dotenv.config();
 
 import express from 'express';
 import { createServer } from 'http';


### PR DESCRIPTION
## Summary
- load environment variables early in server startup via `dotenv`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b8e41701c0832d9b0cde937fcce07c