### PR TITLE
feat: default API port to 3006

### DIFF
--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -46,7 +46,7 @@ class Config {
       maxTokens: 4096,
       
       // API Configuration
-      apiPort: process.env.PORT || 3000,
+      apiPort: process.env.PORT || 3006,
       apiHost: process.env.HOST || 'localhost',
       corsEnabled: true
     };


### PR DESCRIPTION
## Summary
- default apiPort configuration to `process.env.PORT || 3006`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'express')*
- `node -e "import('./src/config/Config.js').then(m => console.log('Default port:', new m.default().get('apiPort')));"`


------
https://chatgpt.com/codex/tasks/task_e_68b8e4157f78832da51b03c1ac8ef95d