### PR TITLE
chore: stop copying non-existent jest config

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -57,7 +57,7 @@ try {
   // Copy configuration and docs
   const filesToCopy = [
     'README.md', 'package.json', 'package-lock.json',
-    'server.js', 'jest.config.js', '.env.example'
+    'server.js', '.env.example'
   ];
   
   for (const file of filesToCopy) {


### PR DESCRIPTION
## Summary
- remove `jest.config.js` from build artifact copy list to avoid references to missing config file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*
- `npm run build` *(fails: Cannot find module '.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b9c8aa911c832db3f31c8b4c6cf276