### PR TITLE
Install dev dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,17 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install dependencies including dev packages for build
+RUN npm ci
 
 # Copy source code
 COPY . .
 
 # Build the project
 RUN npm run build
+
+# Remove development dependencies to slim runtime image
+RUN npm prune --production
 
 # Stage 2: Runtime
 FROM node:20-alpine


### PR DESCRIPTION
## Summary
- install dev dependencies during Docker build
- prune dev dependencies after building to slim runtime image

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '.../node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b9ca9bdf70832da125b9e4f9092793