### PR TITLE
chore: require Node.js 20

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -76,8 +76,8 @@ check_prerequisites() {
         missing_deps+=("nodejs")
     else
         NODE_VERSION=$(node --version | cut -d'v' -f2)
-        if [[ $(echo "$NODE_VERSION 18.0.0" | tr " " "\n" | sort -V | head -n1) != "18.0.0" ]]; then
-            warning "Node.js version $NODE_VERSION detected. Minimum required: 18.0.0"
+        if [[ $(echo "$NODE_VERSION 20.0.0" | tr " " "\n" | sort -V | head -n1) != "20.0.0" ]]; then
+            warning "Node.js version $NODE_VERSION detected. Node.js 20.0.0 or higher is required"
             missing_deps+=("nodejs-update")
         else
             success "Node.js $NODE_VERSION is compatible"


### PR DESCRIPTION
## Summary
- require Node.js 20.0.0 or newer in setup script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b9caaa77ec832d938c5fd3667dfcf5