### PR TITLE
Use relative model registry paths

### DIFF
--- a/backup/test-files/test-smollm3.mjs
+++ b/backup/test-files/test-smollm3.mjs
@@ -11,7 +11,8 @@ console.log('🧪 Testing SmolLM3-3B Model Integration...\n');
 
 // Test 1: Verify model files exist
 console.log('📁 Checking SmolLM3-3B files...');
-const modelDir = path.join(__dirname, 'models', 'smollm3-3b');
+const projectRoot = path.resolve(__dirname, '..', '..');
+const modelDir = path.join(projectRoot, 'models', 'smollm3-3b');
 const requiredFiles = [
     'config.json',
     'model-00001-of-00002.safetensors',
@@ -40,7 +41,7 @@ if (!filesOK) {
 
 // Test 2: Verify registry entry
 console.log('\n📚 Checking model registry...');
-const registryPath = path.join(__dirname, 'models', 'registry.json');
+const registryPath = path.join(projectRoot, 'models', 'registry.json');
 if (fs.existsSync(registryPath)) {
     const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
     const smollm3Model = registry.models.find(m => m.id === 'smollm3-3b');
@@ -50,7 +51,7 @@ if (fs.existsSync(registryPath)) {
         console.log(`     - ID: ${smollm3Model.id}`);
         console.log(`     - Name: ${smollm3Model.name}`);
         console.log(`     - Format: ${smollm3Model.format}`);
-        console.log(`     - Path: ${smollm3Model.path}`);
+        console.log(`     - Path: ${smollm3Model.path || smollm3Model.source}`);
         console.log(`     - Architecture: ${smollm3Model.architecture.type}`);
         console.log(`     - Parameters: ${(smollm3Model.parameters.total_size / 1024 / 1024 / 1024).toFixed(2)} GB`);
     } else {

--- a/dist/src/core/Registry.js
+++ b/dist/src/core/Registry.js
@@ -573,7 +573,18 @@ class ModelRegistry extends EventEmitter {
   async registerFromData(data) {
     const loader = this.loaders.get(data.format);
     if (!loader) return null;
-    
+
+    const relativeSource = data.path || data.source || '';
+    let resolvedSource = relativeSource;
+    if (relativeSource && !path.isAbsolute(relativeSource)) {
+      resolvedSource = relativeSource.startsWith('models')
+        || relativeSource.startsWith('./models')
+        ? path.resolve(process.cwd(), relativeSource)
+        : path.resolve(process.cwd(), 'models', relativeSource);
+    }
+    data.source = resolvedSource;
+    data.path = resolvedSource;
+
     const model = await loader.fromData(data);
     this.models.set(model.id, model);
     this.indexModel(model);

--- a/models/registry.json
+++ b/models/registry.json
@@ -5,7 +5,7 @@
       "id": "simple-smollm3",
       "name": "SmolLM3-3B Simple",
       "format": "safetensors",
-      "source": "/home/mikecerqua/projects/LLM-Runner-Router/models/smollm3-3b",
+      "source": "./smollm3-3b",
       "loaded": true
     }
   ]

--- a/src/core/Registry.js
+++ b/src/core/Registry.js
@@ -586,7 +586,18 @@ class ModelRegistry extends EventEmitter {
   async registerFromData(data) {
     const loader = this.loaders.get(data.format);
     if (!loader) return null;
-    
+
+    const relativeSource = data.path || data.source || '';
+    let resolvedSource = relativeSource;
+    if (relativeSource && !path.isAbsolute(relativeSource)) {
+      resolvedSource = relativeSource.startsWith('models')
+        || relativeSource.startsWith('./models')
+        ? path.resolve(process.cwd(), relativeSource)
+        : path.resolve(process.cwd(), 'models', relativeSource);
+    }
+    data.source = resolvedSource;
+    data.path = resolvedSource;
+
     const model = await loader.fromData(data);
     this.models.set(model.id, model);
     this.indexModel(model);

--- a/tests/development/test-model-load.mjs
+++ b/tests/development/test-model-load.mjs
@@ -8,7 +8,8 @@ const __dirname = path.dirname(__filename);
 console.log('Loading LLM Router...');
 
 // Load the registry
-const registryPath = path.join(__dirname, 'models', 'registry.json');
+const projectRoot = path.resolve(__dirname, '..', '..');
+const registryPath = path.join(projectRoot, 'models', 'registry.json');
 if (fs.existsSync(registryPath)) {
     const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
     console.log('\n📚 Registered Models:');
@@ -17,10 +18,10 @@ if (fs.existsSync(registryPath)) {
         console.log(`    Name: ${model.name}`);
         console.log(`    Format: ${model.format}`);
         console.log(`    Size: ${model.parameters.size}`);
-        console.log(`    Path: ${model.path}`);
-        
+        console.log(`    Path: ${model.path || model.source}`);
+
         // Check if model file exists
-        const modelPath = path.join(__dirname, model.path);
+        const modelPath = path.join(projectRoot, 'models', model.path || model.source || '');
         const exists = fs.existsSync(modelPath);
         console.log(`    Status: ${exists ? '✅ Available' : '❌ Not found'}`);
     });


### PR DESCRIPTION
## Summary
- store model sources in `models/registry.json` using relative paths
- resolve registry model paths relative to project root across server and test scripts
- normalize model paths when restoring registry entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b9caa1b410832d9bcc0141742e0091