### PR TITLE
docs: update model download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ cd LLM-Runner-Router
 npm install
 
 # Download a model (optional - uses mock by default)
-npx huggingface-cli download HuggingFaceTB/SmolLM3-3B-Base --local-dir ./models/smollm3-3b
+pip install huggingface_hub
+huggingface-cli download HuggingFaceTB/SmolLM3-3B-Base --local-dir ./models/smollm3-3b
 
 # Start the server
 npm start


### PR DESCRIPTION
## Summary
- replace broken `npx huggingface-cli` invocation with a working installation of `huggingface_hub` and `huggingface-cli` usage for downloading SmolLM3-3B

## Testing
- `pip install huggingface_hub`
- `huggingface-cli download HuggingFaceTB/SmolLM3-3B-Base --local-dir ./models/smollm3-3b --include config.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '.../jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68ba29db6e90832d8d5106d6383baa4f