### PR TITLE
chore: remove deprecated xssFilter header

### DIFF
--- a/dist/src/middleware/security.js
+++ b/dist/src/middleware/security.js
@@ -42,9 +42,6 @@ export function securityHeaders() {
     // Prevent MIME sniffing
     noSniff: true,
     
-    // XSS Protection
-    xssFilter: true,
-    
     // Referrer Policy
     referrerPolicy: { policy: 'same-origin' }
   });

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -42,9 +42,6 @@ export function securityHeaders() {
     // Prevent MIME sniffing
     noSniff: true,
     
-    // XSS Protection
-    xssFilter: true,
-    
     // Referrer Policy
     referrerPolicy: { policy: 'same-origin' }
   });


### PR DESCRIPTION
## Summary
- remove unsupported xssFilter option from Helmet security middleware

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bb366e56b0832dbe22b653d6064705