### PR TITLE
Check SmolLM3 model presence before loading

### DIFF
--- a/tests/router.initialize.test.js
+++ b/tests/router.initialize.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterAll, jest } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+
+const modelDir = path.join(process.cwd(), 'models', 'smollm3-3b');
+
+async function loadServer() {
+  jest.resetModules();
+  const mod = await import('../server.js');
+  return mod;
+}
+
+describe('initializeRouter smollm3 directory check', () => {
+  beforeEach(async () => {
+    // remove directory before each
+    await fs.rm(modelDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(modelDir, { recursive: true, force: true });
+  });
+
+  it('skips loading when model directory missing', async () => {
+    const { initializeRouter, router } = await loadServer();
+    const loadSpy = jest.spyOn(router, 'load').mockResolvedValue({});
+    await initializeRouter();
+    expect(loadSpy).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'simple-smollm3' }));
+    await router.cleanup();
+  });
+
+  it('loads model when directory present', async () => {
+    await fs.mkdir(modelDir, { recursive: true });
+    const { initializeRouter, router } = await loadServer();
+    const loadSpy = jest.spyOn(router, 'load').mockResolvedValue({});
+    await initializeRouter();
+    expect(loadSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'simple-smollm3' }));
+    await router.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- Guard SmolLM3 fallback loading with `fs.existsSync` and log warning if missing
- Drive `/api/models/public` from registry instead of static list
- Add tests covering presence and absence of SmolLM3 directory

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bb36a677c4832d94405708094a6aa1