### PR TITLE
test: ensure database falls back to memory

### DIFF
--- a/tests/db/database-fallback.test.js
+++ b/tests/db/database-fallback.test.js
@@ -1,0 +1,20 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { DatabaseManager } from '../../src/db/DatabaseManager.js';
+
+describe('Database fallback', () => {
+  test('sets fallbackMode true and emits ready when connect fails', async () => {
+    const database = new DatabaseManager({ type: 'sqlite', fallbackToMemory: true });
+    jest.spyOn(database, 'connect').mockRejectedValue(new Error('Connection failed'));
+
+    const readyPromise = new Promise((resolve, reject) => {
+      database.once('ready', resolve);
+      database.once('error', reject);
+    });
+
+    await database.initialize();
+    await expect(readyPromise).resolves.toBeUndefined();
+    expect(database.fallbackMode).toBe(true);
+
+    await database.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for DatabaseManager.initialize when connect fails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test tests/db/database-fallback.test.js` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bb3c0fc894832db19696bc69f8383e