### PR TITLE
Run LLM Router server from source in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,8 @@ COPY package*.json ./
 # Install dependencies including dev packages for build
 RUN npm ci
 
-# Copy source code
+# Copy source code (no build step required)
 COPY . .
-
-# Build the project
-RUN npm run build
 
 # Remove development dependencies to slim runtime image
 RUN npm prune --production

--- a/docs/examples/DOCKER.md
+++ b/docs/examples/DOCKER.md
@@ -363,9 +363,8 @@ RUN apk add --no-cache python3 make g++
 COPY package*.json ./
 COPY src/ ./src/
 
-# Install all dependencies and build
+# Install all dependencies
 RUN npm ci
-RUN npm run build
 
 # Production stage
 FROM node:18-alpine AS production
@@ -381,8 +380,7 @@ COPY package*.json ./
 # Install only production dependencies
 RUN npm ci --only=production && npm cache clean --force
 
-# Copy built application from builder stage
-COPY --from=builder /app/dist ./dist
+# Copy application source from builder stage
 COPY --from=builder /app/src ./src
 
 # Create non-root user
@@ -431,7 +429,7 @@ COPY src/ ./src/
 COPY scripts/ ./scripts/
 
 RUN npm ci
-RUN npm run build
+RUN npm prune --production
 
 # Production stage
 FROM base AS production
@@ -439,7 +437,6 @@ FROM base AS production
 COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 
-COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src ./src
 
 RUN addgroup -g 1001 -S nodejs && \


### PR DESCRIPTION
## Summary
- Build Docker image without a dist step and run the server from `src`
- Document running container directly from source in deployment guides

## Testing
- `npm run lint` *(fails: 'Deno' is not defined)*
- `npm test` *(fails: sharp module missing)*
- `npm start` *(fails: sharp module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc40413038832da79787c0d9080a7e