### PR TITLE
Add WASM engine with fallback selection and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for production setup.
 - **BYOK System**: Complete with web interface and encryption
 - **Streaming**: StreamProcessor with async token generation
 - **Runtime Features**: Memory Manager, Cache Manager, Thread Pool
+- **WASM Engine**: Universal WebAssembly runtime for broad compatibility
 
 #### ⚠️ Partially Implemented
 - **Cloud Providers**: Basic configs exist but need full integration:
@@ -113,7 +114,6 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for production setup.
 #### ❌ Not Yet Implemented
 - **Ollama Integration**: Loader exists but not complete
 - **WebGPU Engine**: Planned but not implemented
-- **WASM Engine**: Mentioned but no implementation
 - **Edge Computing**: No specific optimizations yet
 - **WebSocket/SSE**: StreamProcessor exists but not full bidirectional support
 - **Enterprise Features**: Compliance features not implemented
@@ -177,7 +177,7 @@ Perfect for developers building AI applications, researchers comparing models, a
 ### ⚡ Multi-Engine Runtime Architecture
 - **Node.js Engine**: ✅ High-performance server-side inference
 - **WebGPU Engine**: ❌ Planned but not yet implemented
-- **WASM Engine**: ❌ Planned but not yet implemented
+- **WASM Engine**: ✅ WebAssembly fallback for universal deployment
 - **Edge Computing**: ❌ No specific optimizations implemented yet
 
 ### 🧭 Intelligent Model Routing Strategies

--- a/tests/wasm-engine.test.js
+++ b/tests/wasm-engine.test.js
@@ -1,0 +1,34 @@
+import { WASMEngine } from '../src/engines/WASMEngine.js';
+
+describe('WASMEngine basic inference', () => {
+  let engine;
+  const model = {
+    name: 'wasm-dummy',
+    size: 4,
+    weights: new Float32Array([0]),
+    outputSize: 1
+  };
+
+  beforeAll(async () => {
+    engine = new WASMEngine();
+    await engine.initialize();
+    await engine.loadModel(model);
+  });
+
+  afterAll(async () => {
+    await engine.cleanup();
+  });
+
+  test('executes inference', async () => {
+    const result = await engine.execute(model, new Float32Array([0]));
+    expect(result).toEqual([42]);
+  });
+
+  test('streams tokens', async () => {
+    const tokens = [];
+    for await (const token of engine.stream(model, new Float32Array([0]), { maxTokens: 2 })) {
+      tokens.push(token[0]);
+    }
+    expect(tokens).toEqual([42, 42]);
+  });
+});


### PR DESCRIPTION
## Summary
- add WebAssembly engine that loads a base WASM module, manages memory, runs inference, and streams tokens
- update EngineSelector with WASM fallback when WebGPU and Node engines are unavailable
- document WASM engine in README and add basic inference unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bc430d2d54832dab5727a4338216e4