### PR TITLE
test: reset environment after tests

### DIFF
--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -8,16 +8,20 @@ describe('LLM Runner Router', () => {
   });
   test('selects Node engine when available', async () => {
     const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-    jest.resetModules();
-    const { EngineSelector } = await import('../src/engines/EngineSelector.js');
-    EngineSelector.engines.clear();
-    EngineSelector.initialized = false;
-    const engine = await EngineSelector.getBest();
-    expect(engine.constructor.name).toBe('NodeEngine');
-    await engine.cleanup?.();
-    EngineSelector.engines.clear();
-    EngineSelector.initialized = false;
-    process.env.NODE_ENV = originalEnv;
+    let EngineSelector;
+    try {
+      process.env.NODE_ENV = 'production';
+      jest.resetModules();
+      ({ EngineSelector } = await import('../src/engines/EngineSelector.js'));
+      EngineSelector.engines.clear();
+      EngineSelector.initialized = false;
+      const engine = await EngineSelector.getBest();
+      expect(engine.constructor.name).toBe('NodeEngine');
+      await engine.cleanup?.();
+    } finally {
+      EngineSelector?.engines.clear();
+      if (EngineSelector) EngineSelector.initialized = false;
+      process.env.NODE_ENV = originalEnv;
+    }
   });
 });

--- a/tests/final-validation.test.js
+++ b/tests/final-validation.test.js
@@ -12,8 +12,12 @@ import { Pipeline } from '../src/core/Pipeline.js';
 describe('Final Project Validation', () => {
   let router;
   let registry;
+  let originalNodeEnv;
+  let originalAutoInit;
 
   beforeAll(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    originalAutoInit = process.env.AUTO_INIT;
     process.env.NODE_ENV = 'test';
     process.env.AUTO_INIT = 'false';
   });
@@ -208,6 +212,12 @@ describe('Final Project Validation', () => {
     }
     if (registry) {
       registry = null;
+    }
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalAutoInit === undefined) {
+      delete process.env.AUTO_INIT;
+    } else {
+      process.env.AUTO_INIT = originalAutoInit;
     }
   });
 });

--- a/tests/integration/webgpu-engine.test.js
+++ b/tests/integration/webgpu-engine.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 const skipIfNoWebGPU = () => {
   if (typeof navigator === 'undefined' || !navigator.gpu) {
@@ -9,17 +9,27 @@ const skipIfNoWebGPU = () => {
 };
 
 describe('WebGPU Engine Integration', () => {
-  beforeAll(() => {
+  let originalEnv;
+
+  beforeEach(async () => {
     // Ensure production mode so EngineSelector loads full engines
+    originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
+    const { EngineSelector } = await import('../../src/engines/EngineSelector.js');
+    EngineSelector.engines.clear();
+    EngineSelector.initialized = false;
+  });
+
+  afterEach(async () => {
+    const { EngineSelector } = await import('../../src/engines/EngineSelector.js');
+    EngineSelector.engines.clear();
+    EngineSelector.initialized = false;
+    process.env.NODE_ENV = originalEnv;
   });
 
   it('selects WebGPU engine when available', async () => {
     if (skipIfNoWebGPU()) return;
     const { EngineSelector } = await import('../../src/engines/EngineSelector.js');
-    // reset selector state for clean test
-    EngineSelector.engines.clear();
-    EngineSelector.initialized = false;
     const engine = await EngineSelector.getBest();
     expect(engine.name).toBe('WebGPU');
     await engine.cleanup();

--- a/tests/monitoring/monitoring.test.js
+++ b/tests/monitoring/monitoring.test.js
@@ -17,16 +17,9 @@ import middleware from '../../src/monitoring/middleware.js';
 describe('Monitoring System', () => {
   let originalEnv;
 
-  beforeAll(() => {
+  beforeEach(async () => {
     originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'test';
-  });
-
-  afterAll(() => {
-    process.env.NODE_ENV = originalEnv;
-  });
-
-  beforeEach(async () => {
     // Reset monitoring system state
     if (monitoringSystem.isRunning) {
       await monitoringSystem.stop();
@@ -38,6 +31,7 @@ describe('Monitoring System', () => {
     if (monitoringSystem.isRunning) {
       await monitoringSystem.stop();
     }
+    process.env.NODE_ENV = originalEnv;
   });
 
   describe('MonitoringSystem Core', () => {


### PR DESCRIPTION
## Summary
- wrap NODE_ENV mutation in basic tests with try/finally and reset EngineSelector
- reset NODE_ENV and EngineSelector state in WebGPU integration tests via beforeEach/afterEach
- ensure monitoring and final-validation tests restore modified environment variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module '.../node_modules/.bin/jest')*


------
https://chatgpt.com/codex/tasks/task_e_68bc47a206e4832db5a9c69051469ced