### PR TITLE
feat(auth): persist auth data and use env secrets

### DIFF
--- a/src/db/PersistentMap.js
+++ b/src/db/PersistentMap.js
@@ -1,0 +1,73 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export class PersistentMap {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.map = new Map();
+  }
+
+  async load() {
+    try {
+      const data = await fs.readFile(this.filePath, 'utf8');
+      const obj = JSON.parse(data);
+      this.map = new Map(Object.entries(obj));
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        await this.save();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  async save() {
+    const dir = path.dirname(this.filePath);
+    await fs.mkdir(dir, { recursive: true });
+    const obj = Object.fromEntries(this.map);
+    await fs.writeFile(this.filePath, JSON.stringify(obj, null, 2));
+  }
+
+  get size() {
+    return this.map.size;
+  }
+
+  get(key) {
+    return this.map.get(key);
+  }
+
+  set(key, value) {
+    this.map.set(key, value);
+    this.save().catch(() => {});
+    return this;
+  }
+
+  delete(key) {
+    const res = this.map.delete(key);
+    this.save().catch(() => {});
+    return res;
+  }
+
+  clear() {
+    this.map.clear();
+    this.save().catch(() => {});
+  }
+
+  values() {
+    return this.map.values();
+  }
+
+  entries() {
+    return this.map.entries();
+  }
+
+  has(key) {
+    return this.map.has(key);
+  }
+
+  [Symbol.iterator]() {
+    return this.map[Symbol.iterator]();
+  }
+}
+
+export default PersistentMap;

--- a/tests/api/Auth.test.js
+++ b/tests/api/Auth.test.js
@@ -12,11 +12,27 @@ describe('Authentication & Authorization', () => {
   let authManager;
   let authMiddleware;
 
+  beforeAll(async () => {
+    const adminHash = await bcrypt.hash('admin123', 4);
+    const userHash = await bcrypt.hash('user123', 4);
+    const apiHash = await bcrypt.hash('api123', 4);
+    process.env.DEFAULT_ADMIN_PASSWORD_HASH = adminHash;
+    process.env.DEFAULT_USER_PASSWORD_HASH = userHash;
+    process.env.DEFAULT_API_PASSWORD_HASH = apiHash;
+  });
+
+  afterAll(() => {
+    delete process.env.DEFAULT_ADMIN_PASSWORD_HASH;
+    delete process.env.DEFAULT_USER_PASSWORD_HASH;
+    delete process.env.DEFAULT_API_PASSWORD_HASH;
+  });
+
   beforeEach(async () => {
     authManager = new AuthenticationManager({
       jwtSecret: 'test-secret-key',
       jwtExpiresIn: '1h',
-      bcryptRounds: 4 // Lower for faster tests
+      bcryptRounds: 4, // Lower for faster tests
+      sessionSecret: 'test-session-secret'
     });
     
     authMiddleware = new AuthMiddleware(authManager);

--- a/tests/integration/auth.persistence.test.js
+++ b/tests/integration/auth.persistence.test.js
@@ -1,0 +1,63 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import jwt from 'jsonwebtoken';
+import { AuthenticationManager } from '../../src/api/Auth.js';
+
+describe('Persistent auth storage', () => {
+  test('persists users and revokes tokens', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'auth-store-'));
+
+    const auth1 = new AuthenticationManager({
+      jwtSecret: 'persist-secret',
+      bcryptRounds: 4,
+      sessionSecret: 'persist-session',
+      dataDir: dir
+    });
+    await new Promise(res => auth1.on('initialized', res));
+
+    const user = await auth1.createUser({
+      username: 'alice',
+      password: 'password123',
+      email: 'alice@example.com',
+      role: 'user'
+    });
+
+    const tokens = auth1.generateTokens(user);
+    const decoded = jwt.decode(tokens.refreshToken);
+    auth1.removeAllListeners();
+
+    const auth2 = new AuthenticationManager({
+      jwtSecret: 'persist-secret',
+      bcryptRounds: 4,
+      sessionSecret: 'persist-session',
+      dataDir: dir
+    });
+    await new Promise(res => auth2.on('initialized', res));
+
+    const persistedUser = Array.from(auth2.users.values()).find(u => u.username === 'alice');
+    expect(persistedUser).toBeDefined();
+
+    const authUser = await auth2.authenticateUser('alice', 'password123');
+    expect(authUser).toBeDefined();
+
+    const storedToken = auth2.refreshTokens.get(decoded.jti);
+    expect(storedToken).toBeDefined();
+
+    auth2.revokeToken(tokens.refreshToken);
+    const revoked = auth2.refreshTokens.get(decoded.jti);
+    expect(revoked).toBeUndefined();
+
+    auth2.removeAllListeners();
+
+    const auth3 = new AuthenticationManager({
+      jwtSecret: 'persist-secret',
+      bcryptRounds: 4,
+      sessionSecret: 'persist-session',
+      dataDir: dir
+    });
+    await new Promise(res => auth3.on('initialized', res));
+    const afterReload = auth3.refreshTokens.get(decoded.jti);
+    expect(afterReload).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add persistent JSON-backed storage for users, API keys, and refresh tokens
- require JWT and session secrets from environment
- support env-provided password hashes and disable default users in production
- test user lifecycle, login, and token revocation against persistent storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bc479372b8832d916f30a4a08750d9