### PR TITLE
test: replace placeholder math tests with functional coverage

### DIFF
--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,11 +1,10 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
 describe('LLM Runner Router', () => {
-  test('basic placeholder test', () => {
-    expect(1 + 1).toBe(2);
-  });
-  
   test('environment check', () => {
     expect(process.env.NODE_ENV || 'test').toBeTruthy();
   });
+
   test('selects Node engine when available', async () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
@@ -19,5 +18,32 @@ describe('LLM Runner Router', () => {
     EngineSelector.engines.clear();
     EngineSelector.initialized = false;
     process.env.NODE_ENV = originalEnv;
+  });
+
+  test('router selects model matching capability', async () => {
+    const { Router } = await import('../src/core/Router.js');
+    const mockRegistry = {
+      getAvailable: jest.fn().mockResolvedValue([
+        {
+          id: 'text',
+          name: 'TextModel',
+          format: 'mock',
+          parameters: { size: 1 },
+          supports: (cap) => cap === 'textGeneration'
+        },
+        {
+          id: 'embed',
+          name: 'EmbedModel',
+          format: 'mock',
+          parameters: { size: 1 },
+          supports: (cap) => cap === 'embedding'
+        }
+      ])
+    };
+    const router = new Router(mockRegistry, { strategy: 'capability-match' });
+    const model = await router.selectModel('hi', {
+      capabilities: { embedding: true }
+    });
+    expect(model.id).toBe('embed');
   });
 });

--- a/tests/final.test.js
+++ b/tests/final.test.js
@@ -8,12 +8,17 @@ import { describe, it, expect } from '@jest/globals';
 describe('Final Test Suite - Core Functionality', () => {
   
   describe('Basic Functionality', () => {
-    it('should pass basic test', () => {
-      expect(1 + 1).toBe(2);
-    });
-    
     it('should verify environment', () => {
       expect(process.env.NODE_ENV).toBe('test');
+    });
+
+    it('initializes EngineSelector in test mode', async () => {
+      const { EngineSelector } = await import('../src/engines/EngineSelector.js');
+      EngineSelector.engines.clear();
+      EngineSelector.initialized = false;
+      await EngineSelector.initialize();
+      const available = EngineSelector.getAvailable();
+      expect(available.length).toBeGreaterThan(0);
     });
   });
   

--- a/tests/simple.test.js
+++ b/tests/simple.test.js
@@ -2,13 +2,22 @@
  * Simple test to verify basic functionality
  */
 
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 
 describe('Simple Tests', () => {
-  it('should pass basic math', () => {
-    expect(1 + 1).toBe(2);
+  it('initializes Router with mock engine', async () => {
+    const { Router } = await import('../src/core/Router.js');
+    const mockRegistry = { getAll: jest.fn().mockResolvedValue([]) };
+    const router = new Router(mockRegistry);
+    const computeSpy = jest.spyOn(router, 'computeModelScores').mockResolvedValue();
+    const monitorSpy = jest.spyOn(router, 'startMonitoring').mockImplementation(() => {});
+    await router.initialize({ name: 'test-engine' });
+    expect(router.engine.name).toBe('test-engine');
+    expect(computeSpy).toHaveBeenCalled();
+    expect(monitorSpy).toHaveBeenCalled();
+    router.stopMonitoring();
   });
-  
+
   it('should import LLMRouter', async () => {
     const { LLMRouter } = await import('../src/index.js');
     expect(LLMRouter).toBeDefined();


### PR DESCRIPTION
## Summary
- remove placeholder math assertions from basic, simple and final test suites
- add capability-based router selection test
- ensure router initialization and engine selector logic are exercised without external dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*
- `npm start` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4790d764832dbcecb774c7e94c41