### PR TITLE
feat: centralize BASE_URL config

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -11,7 +11,7 @@ Complete guide to all environment variables used in the LLM Runner Router projec
 | `NODE_ENV` | `production` | Environment mode (production/development/test) | No |
 | `SERVER_MODE` | `production` | Server mode (production/secure/resilient/development) | No |
 | `HOST` | `0.0.0.0` | Server host binding | No |
-| `BASE_URL` | `https://llmrouter.dev:3006` | Base URL for the application | No |
+| `BASE_URL` | `http://localhost:3006` (development), `https://llmrouter.dev:3006` (production) | Base URL for the application | No |
 
 ### Model Configuration
 | Variable | Default | Description | Required |

--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -10,6 +10,7 @@ export LOG_LEVEL=info
 export API_PORT=3006
 export DEFAULT_STRATEGY=balanced
 export MAX_MODELS=10
+BASE_URL="${BASE_URL:-http://localhost:3006}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -125,6 +126,6 @@ print_info "📡 Available Commands:"
 echo "  npm start                 - Start production server"
 echo "  npm run monitor          - Monitor with PM2"
 echo "  npm run logs             - View logs"
-echo "  curl localhost:3006/api/health - Health check"
+echo "  curl $BASE_URL/api/health - Health check"
 echo ""
 print_status "✅ Deployment ready!"

--- a/deploy-secure.sh
+++ b/deploy-secure.sh
@@ -14,8 +14,9 @@ pm2 save
 
 # Test localhost binding
 sleep 3
-if curl -s http://127.0.0.1:3006/api/health > /dev/null; then
-    echo "✅ Service running on localhost:3006"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+if curl -s "$BASE_URL/api/health" > /dev/null; then
+    echo "✅ Service running on ${BASE_URL}"
 else
     echo "❌ Service not responding on localhost"
     exit 1

--- a/functional-llm-router-tests.sh
+++ b/functional-llm-router-tests.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Configuration
-BASE_URL="http://localhost:3006"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
 API_KEY="${ROUTER_API_KEY:-your-api-key-here}"
 TOTAL_TESTS=0
 PASSED_TESTS=0

--- a/run-functional-tests.sh
+++ b/run-functional-tests.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+
 echo "🧠 Loading environment and running LLM Router functional tests..."
 
 # Load API key from .env.test file (for testing)
@@ -22,7 +24,7 @@ fi
 # Set the API key for the functional tests
 export ROUTER_API_KEY="$API_KEY"
 
-echo "🚀 Starting functional tests against local server (http://localhost:3006)"
+echo "🚀 Starting functional tests against server (${BASE_URL})"
 echo "🔑 Using API key: ${API_KEY:0:20}..."
 echo ""
 

--- a/scripts/autonomous-update.sh
+++ b/scripts/autonomous-update.sh
@@ -114,7 +114,8 @@ validate_update() {
     sleep 10
     
     # Health check
-    if curl -f -s http://localhost:3006/api/health > /dev/null 2>&1; then
+    BASE_URL="${BASE_URL:-http://localhost:3006}"
+    if curl -f -s "$BASE_URL/api/health" > /dev/null 2>&1; then
         success "Server startup test passed"
         kill $SERVER_PID 2>/dev/null || true
         return 0

--- a/scripts/deployment/configure-firewall.sh
+++ b/scripts/deployment/configure-firewall.sh
@@ -20,6 +20,8 @@ ufw status verbose
 echo ""
 echo "🔧 Configuring firewall rules..."
 
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+
 # Enable UFW if not already enabled
 if ! ufw status | grep -q "Status: active"; then
     echo "⚠️  UFW is not active. Enabling UFW..."
@@ -59,7 +61,7 @@ echo "🔍 Testing accessibility..."
 
 # Test local connectivity
 echo -n "  Local API (3006): "
-if curl -s -o /dev/null -w "%{http_code}" http://localhost:3006/api/health | grep -q "200"; then
+if curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/health" | grep -q "200"; then
     echo "✅ Working"
 else
     echo "❌ Not responding"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -171,7 +171,8 @@ echo -e "\n${YELLOW}🔍 Running post-deployment checks...${NC}"
 sleep 5
 
 # Check health endpoint
-if curl -f http://localhost:3006/health > /dev/null 2>&1; then
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+if curl -f "$BASE_URL/health" > /dev/null 2>&1; then
     echo -e "${GREEN}✅ Server health check passed${NC}"
 else
     echo -e "${YELLOW}⚠️  Server may still be starting up${NC}"
@@ -180,9 +181,9 @@ fi
 # Display important information
 echo -e "\n${GREEN}=== Deployment Complete ===${NC}"
 echo -e "\n📝 Important Information:"
-echo -e "- Health check: http://localhost:3006/health"
-echo -e "- Chat interface: http://localhost:3006/chat"
-echo -e "- API endpoint: http://localhost:3006/api/inference"
+echo -e "- Health check: $BASE_URL/health"
+echo -e "- Chat interface: $BASE_URL/chat"
+echo -e "- API endpoint: $BASE_URL/api/inference"
 echo -e "- Logs directory: ./logs/"
 
 if [ -f .env.production ]; then

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -12,7 +12,8 @@ LOG_FILE="$PROJECT_DIR/monitoring.log"
 ALERT_LOG="$PROJECT_DIR/alerts.log"
 
 # Configuration
-HEALTH_URL="http://localhost:3006/api/health"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+HEALTH_URL="$BASE_URL/api/health"
 CHECK_INTERVAL=30
 MAX_MEMORY_MB=1536  # 1.5GB
 MAX_CPU_PERCENT=80

--- a/scripts/recovery.sh
+++ b/scripts/recovery.sh
@@ -97,16 +97,17 @@ check_pm2_status() {
 # Function to check API health
 check_api_health() {
     info "Checking API health..."
-    
+
     # Check health endpoint
-    HEALTH_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3006/health)
+    BASE_URL="${BASE_URL:-http://localhost:3006}"
+    HEALTH_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/health")
     if [ "$HEALTH_RESPONSE" != "200" ]; then
         error "Health check failed (HTTP $HEALTH_RESPONSE)"
         return 1
     fi
     
     # Check response time
-    RESPONSE_TIME=$(curl -s -o /dev/null -w "%{time_total}" http://localhost:3006/health)
+    RESPONSE_TIME=$(curl -s -o /dev/null -w "%{time_total}" "$BASE_URL/health")
     if (( $(echo "$RESPONSE_TIME > 5" | bc -l) )); then
         warning "Slow API response: ${RESPONSE_TIME}s"
     fi

--- a/scripts/security-setup.sh
+++ b/scripts/security-setup.sh
@@ -19,6 +19,7 @@ PROJECT_DIR="/home/mikecerqua/projects/LLM-Runner-Router"
 SERVICE_NAME="llm-router-saas"
 DOMAIN="${1:-llm-api.local}"  # Use provided domain or default
 PUBLIC_IP="178.156.181.117"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
 
 echo -e "${YELLOW}📋 Configuration:${NC}"
 echo -e "  Project: $PROJECT_DIR"
@@ -343,7 +344,7 @@ pm2 save
 # Test localhost binding
 sleep 3
 if curl -s http://127.0.0.1:3006/api/health > /dev/null; then
-    echo "✅ Service running on localhost:3006"
+    echo "✅ Service running on ${BASE_URL}"
 else
     echo "❌ Service not responding on localhost"
     exit 1

--- a/scripts/simple-recovery.sh
+++ b/scripts/simple-recovery.sh
@@ -55,9 +55,10 @@ check_pm2_status() {
 # Check API health
 check_api_health() {
     info "Checking API health..."
-    
+
     # Check health endpoint
-    if curl -s -f -o /dev/null http://localhost:3006/health; then
+    BASE_URL="${BASE_URL:-http://localhost:3006}"
+    if curl -s -f -o /dev/null "$BASE_URL/health"; then
         log "API health check passed"
         return 0
     else

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_FILE="$SCRIPT_DIR/setup.log"
 ERROR_LOG="$SCRIPT_DIR/setup-errors.log"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -351,7 +352,8 @@ setup_monitoring() {
 #!/bin/bash
 # Health check script for LLM Router
 
-HEALTH_URL="http://localhost:3006/api/health"
+BASE_URL="${BASE_URL:-http://localhost:3006}"
+HEALTH_URL="$BASE_URL/api/health"
 MAX_RETRIES=3
 RETRY_DELAY=5
 
@@ -515,7 +517,7 @@ main() {
     fi
     
     echo ""
-    log "📚 Documentation: http://localhost:3006/docs.html"
+    log "📚 Documentation: $BASE_URL/docs.html"
     log "🔗 Repository: https://github.com/MCERQUA/LLM-Runner-Router"
 }
 

--- a/tests/api/Gateway.test.js
+++ b/tests/api/Gateway.test.js
@@ -7,6 +7,8 @@ import { jest } from '@jest/globals';
 import { APIGateway } from '../../src/api/Gateway.js';
 import request from 'supertest';
 
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3006';
+
 // Mock fetch for service calls
 global.fetch = jest.fn();
 
@@ -752,7 +754,7 @@ describe.skip('API Gateway', () => {
     test('should handle CORS preflight requests', (done) => {
       request(app)
         .options('/api/v1/test')
-        .set('Origin', 'http://localhost:3006')
+        .set('Origin', BASE_URL)
         .expect(200)
         .end((err, res) => {
           if (err) return done(err);

--- a/tests/api/OpenAPI.test.js
+++ b/tests/api/OpenAPI.test.js
@@ -8,6 +8,8 @@ import { OpenAPIManager } from '../../src/api/OpenAPI.js';
 import express from 'express';
 import request from 'supertest';
 
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3006';
+
 describe('OpenAPI System', () => {
   let openAPIManager;
   let app;
@@ -16,7 +18,7 @@ describe('OpenAPI System', () => {
     openAPIManager = new OpenAPIManager({
       title: 'Test LLM Router API',
       version: '1.0.0-test',
-      serverUrl: 'http://localhost:3006'
+      serverUrl: BASE_URL
     });
 
     app = express();
@@ -470,7 +472,7 @@ describe('OpenAPI System', () => {
       
       const devServer = servers.find(s => s.description === 'Development server');
       expect(devServer).toBeDefined();
-      expect(devServer.url).toBe('http://localhost:3006');
+      expect(devServer.url).toBe(BASE_URL);
     });
   });
 

--- a/tests/e2e/real-world-integration.test.js
+++ b/tests/e2e/real-world-integration.test.js
@@ -15,7 +15,7 @@ describe('Real-World E2E Integration Tests', () => {
   let router;
   let database;
   let apiClient;
-  const baseURL = process.env.API_URL || 'http://localhost:3006';
+  const BASE_URL = process.env.BASE_URL || 'http://localhost:3006';
   
   beforeAll(async () => {
     // Initialize real components
@@ -38,7 +38,7 @@ describe('Real-World E2E Integration Tests', () => {
     
     // Setup API client
     apiClient = axios.create({
-      baseURL,
+      baseURL: BASE_URL,
       timeout: 30000,
       validateStatus: () => true // Don't throw on any status
     });

--- a/tests/load/artillery-config.yml
+++ b/tests/load/artillery-config.yml
@@ -1,5 +1,5 @@
 config:
-  target: 'http://localhost:3006'
+  target: "{{ $processEnvironment.BASE_URL || 'http://localhost:3006' }}"
   phases:
     # Warm-up phase
     - duration: 60
@@ -31,7 +31,7 @@ config:
   processor: './artillery-processor.js'
   environments:
     development:
-      target: 'http://localhost:3006'
+      target: "{{ $processEnvironment.BASE_URL || 'http://localhost:3006' }}"
     staging:
       target: 'https://staging.llm-router.com'
     production:

--- a/tests/test-byok.js
+++ b/tests/test-byok.js
@@ -10,7 +10,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const API_BASE = process.env.API_BASE || 'http://localhost:3006';
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3006';
 const TEST_API_KEY = 'llm_test_persistent_key_fixed_2025.TEST_SECRET_KEY_2025_PERSISTENT';
 
 console.log('🧪 BYOK System Test Suite\n');
@@ -116,7 +116,7 @@ async function testBYOKAPI() {
   // Test 1: Get supported providers
   console.log('Test 1: GET /api/byok/providers');
   try {
-    const response = await fetch(`${API_BASE}/api/byok/providers`);
+    const response = await fetch(`${BASE_URL}/api/byok/providers`);
     const data = await response.json();
     
     if (data.success) {
@@ -131,7 +131,7 @@ async function testBYOKAPI() {
   // Test 2: Get user providers (requires auth)
   console.log('\nTest 2: GET /api/byok/keys (authenticated)');
   try {
-    const response = await fetch(`${API_BASE}/api/byok/keys`, {
+    const response = await fetch(`${BASE_URL}/api/byok/keys`, {
       headers: {
         'Authorization': `Bearer ${TEST_API_KEY}`
       }
@@ -150,7 +150,7 @@ async function testBYOKAPI() {
   // Test 3: Add a mock key
   console.log('\nTest 3: POST /api/byok/keys/:provider');
   try {
-    const response = await fetch(`${API_BASE}/api/byok/keys/openai`, {
+    const response = await fetch(`${BASE_URL}/api/byok/keys/openai`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${TEST_API_KEY}`,
@@ -168,7 +168,7 @@ async function testBYOKAPI() {
       console.log(`  ✅ Added key: ${data.keyId}`);
       
       // Clean up - remove the test key
-      const deleteResponse = await fetch(`${API_BASE}/api/byok/keys/openai`, {
+      const deleteResponse = await fetch(`${BASE_URL}/api/byok/keys/openai`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${TEST_API_KEY}`


### PR DESCRIPTION
## Summary
- centralize BASE_URL via environment variable used across scripts and tests
- document BASE_URL for dev and prod
- replace hard-coded localhost URLs in scripts and tests with BASE_URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `BASE_URL=http://localhost:3006 npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `BASE_URL=https://llmrouter.dev:3006 npm test` *(fails: Cannot find module '/workspace/LLM-Runner-Router/node_modules/.bin/jest')*
- `BASE_URL=http://localhost:3006 bash functional-llm-router-tests.sh` *(fails: Model loading failed. Status: 000)*
- `BASE_URL=https://llmrouter.dev:3006 bash functional-llm-router-tests.sh` *(fails: Model loading failed. Status: 503)*
- `BASE_URL=http://localhost:3006 bash scripts/monitor.sh` *(usage info displayed)*
- `BASE_URL=https://llmrouter.dev:3006 bash scripts/monitor.sh` *(usage info displayed)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4797f450832d91b2217288b74e1d